### PR TITLE
Fix MSVC uninitialised variable error

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -24267,6 +24267,7 @@ static int js_parse_destructuring_element(JSParseState *s, int tok, int is_arg,
                         goto var_error;
                     opcode = OP_scope_get_var;
                     scope = s->cur_func->scope_level;
+                    label_lvalue = -1;
                 } else {
                     if (js_parse_left_hand_side_expr(s))
                         return -1;


### PR DESCRIPTION
`label_lvalue` isn't even used if this code path is taken, but it gets passed to a function, causing VC++ runtime to panic. Initialising it here removes the error.